### PR TITLE
add a netstandard2.0 target framework

### DIFF
--- a/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
+++ b/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
@@ -4,7 +4,7 @@
     <Description>The diagnostic trace sink for Serilog.</Description>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Sinks.Trace</AssemblyName>


### PR DESCRIPTION
The newer target shouldn't need to reference the System.Diagnostics.TraceSource nuget package