### PR TITLE
Replace PackageLicenseUrl with PackageLicenseExpression

### DIFF
--- a/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
+++ b/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>The diagnostic trace sink for Serilog.</Description>
@@ -15,7 +15,7 @@
     <PackageTags>serilog;trace;diagnostic</PackageTags>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
 


### PR DESCRIPTION
Fixes a packaging warning about licenseUrl being deprecated