### PR TITLE
remove secrets from appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,13 +10,13 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: rbdBqxBpLt4MkB+mrDOYNDOd8aVZ1zMkysaVNAXNKnC41FYifzX3l9LM8DCrUWU5
+    secure: %nuget_api_key%
   skip_symbols: true
   on:
     branch: /^(main|dev)$/
 - provider: GitHub
   auth_token:
-    secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
+    secure: %github_auth_token%
   artifact: /Serilog.*\.nupkg/
   tag: v$(appveyor_build_version)
   on:


### PR DESCRIPTION
Storing and publishing the secrets in machine-readable form poses a security risk. a malicious individual could take control of the repository and distribute infected versions via nuget.

Possible solutions:

1. storing secrets as enviorments-variables (like in this pull request) (see: [appveyor / Secure files](https://www.appveyor.com/docs/how-to/secure-files/))
2. using [git-secret](https://git-secret.io/) to store secrets inside the git repository

Note: its important to renew both secrets because the are stored inside the git history too