### PR TITLE
4.0.0 Release

### DIFF
--- a/.idea/.idea.serilog-sinks-trace/.idea/.gitignore
+++ b/.idea/.idea.serilog-sinks-trace/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/modules.xml
+/.idea.serilog-sinks-trace.iml
+/contentModel.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.serilog-sinks-trace/.idea/encodings.xml
+++ b/.idea/.idea.serilog-sinks-trace/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.serilog-sinks-trace/.idea/indexLayout.xml
+++ b/.idea/.idea.serilog-sinks-trace/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.serilog-sinks-trace/.idea/vcs.xml
+++ b/.idea/.idea.serilog-sinks-trace/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Build.ps1
+++ b/Build.ps1
@@ -12,32 +12,24 @@ if(Test-Path .\artifacts) {
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
 $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "main" -and $revision -ne "local"]
+$commitHash = $(git rev-parse --short HEAD)
+$buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
-echo "build: Version suffix is $suffix"
+echo "build: Package version suffix is $suffix"
+echo "build: Build version suffix is $buildSuffix" 
 
 foreach ($src in ls src/*) {
     Push-Location $src
 
 	echo "build: Packaging project in $src"
 
+    & dotnet build -c Release --version-suffix=$buildSuffix -p:EnableSourceLink=true
     if ($suffix) {
-        & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix --include-source
+        & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix --no-build
     } else {
-        & dotnet pack -c Release -o ..\..\artifacts --include-source
+        & dotnet pack -c Release -o ..\..\artifacts --no-build
     }
-    
-    if($LASTEXITCODE -ne 0) { exit 1 }    
-
-    Pop-Location
-}
-
-foreach ($test in ls test/*.PerformanceTests) {
-    Push-Location $test
-
-	echo "build: Building performance test project in $test"
-
-    & dotnet build -c Release
-    if($LASTEXITCODE -ne 0) { exit 2 }
+    if($LASTEXITCODE -ne 0) { throw "build failed" }    
 
     Pop-Location
 }
@@ -48,7 +40,7 @@ foreach ($test in ls test/*.Tests) {
 	echo "build: Testing project in $test"
 
     & dotnet test -c Release
-    if($LASTEXITCODE -ne 0) { exit 3 }
+    if($LASTEXITCODE -ne 0) { throw "tests failed" }    
 
     Pop-Location
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Serilog.Sinks.Trace [![Build status](https://ci.appveyor.com/api/projects/status/v1oe03lx3wymyy7j/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-trace/branch/master) [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Sinks.Trace.svg?style=flat)](https://www.nuget.org/packages/Serilog.Sinks.Trace/)
 
-> **Note:** this sink writes regular log events to `System.Diagnostics.Trace`. If you're looking for distributed/hierarchical tracing with Serilog, see [SerilogTracing](https://github.com/serilog-tracing/serilog-tracing) instead.
+> **Note:** this sink writes regular log events to `System.Diagnostics.Trace`. If you're looking for 
+> distributed/hierarchical tracing with Serilog, see [SerilogTracing](https://github.com/serilog-tracing/serilog-tracing)
+> instead.
 
 Writes [Serilog](https://serilog.net) events to `System.Diagnostics.Trace`.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Serilog.Sinks.Trace [![Build status](https://ci.appveyor.com/api/projects/status/v1oe03lx3wymyy7j/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-trace/branch/master) [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Sinks.Trace.svg?style=flat)](https://www.nuget.org/packages/Serilog.Sinks.Trace/)
 
+> **Note:** this sink writes regular log events to `System.Diagnostics.Trace`. If you're looking for distributed/hierarchical tracing with Serilog, see [SerilogTracing](https://github.com/serilog-tracing/serilog-tracing) instead.
+
 Writes [Serilog](https://serilog.net) events to `System.Diagnostics.Trace`.
 
 ```csharp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,23 +1,22 @@
 version: '{build}'
 skip_tags: true
 image: Visual Studio 2022
-configuration: Release
-test: off
 build_script:
-- pwsh: ./Build.ps1
+    - pwsh: ./Build.ps1
+test: off
 artifacts:
-- path: artifacts/Serilog.*.nupkg
+    - path: artifacts/Serilog.*.nupkg
 deploy:
-- provider: NuGet
-  api_key:
-    secure: sDnchSg4TZIOK7oIUI6BJwFPNENTOZrGNsroGO1hehLJSvlHpFmpTwiX8+bgPD+Q
-  skip_symbols: true
-  on:
-    branch: /^(main|dev)$/
-- provider: GitHub
-  auth_token:
-    secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
-  artifact: /Serilog.*\.nupkg/
-  tag: v$(appveyor_build_version)
-  on:
-    branch: main
+    - provider: NuGet
+      api_key:
+          secure: ZpUO4ECx4c/V0Ecj04cfV1UGd+ZABeEG9DDW2fjG8vITjNYhmbiiJH0qNOnRy2G3
+      skip_symbols: true
+      on:
+          branch: /^(main|dev)$/
+    - provider: GitHub
+      auth_token:
+          secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
+      artifact: /Serilog.*\.nupkg/
+      tag: v$(appveyor_build_version)
+      on:
+          branch: main

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,16 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 test: off
 build_script:
-- ps: ./Build.ps1
+- pwsh: ./Build.ps1
 artifacts:
 - path: artifacts/Serilog.*.nupkg
 deploy:
 - provider: NuGet
   api_key:
-    secure: rbdBqxBpLt4MkB+mrDOYNDOd8aVZ1zMkysaVNAXNKnC41FYifzX3l9LM8DCrUWU5
+    secure: sDnchSg4TZIOK7oIUI6BJwFPNENTOZrGNsroGO1hehLJSvlHpFmpTwiX8+bgPD+Q
   skip_symbols: true
   on:
     branch: /^(main|dev)$/

--- a/serilog-sinks-trace.sln
+++ b/serilog-sinks-trace.sln
@@ -16,7 +16,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{EF92FC
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
 		Build.ps1 = Build.ps1
-		NuGet.Config = NuGet.Config
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
+++ b/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
@@ -31,8 +31,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\..\assets\serilog-sink-nuget.png" Visible="false" PackagePath="/"/>
-        <None Include="..\..\README.md" Visible="false" PackagePath="/"/>
+        <None Include="..\..\assets\serilog-sink-nuget.png" Pack="true" Visible="false" PackagePath="/" />
+        <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="/" />
     </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
+++ b/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
@@ -1,34 +1,38 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>The diagnostic trace sink for Serilog.</Description>
-    <VersionPrefix>3.0.1</VersionPrefix>
-    <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageTags>serilog;trace;diagnostic</PackageTags>
-    <PackageProjectUrl>https://github.com/serilog/serilog-sinks-trace</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageIcon>serilog-sink-nuget.png</PackageIcon>
-  </PropertyGroup>
+    <PropertyGroup>
+        <Description>The System.Diagnostics.Trace sink for Serilog.</Description>
+        <VersionPrefix>4.0.0</VersionPrefix>
+        <Authors>Serilog Contributors</Authors>
+        <!-- .NET Framework version targeting is frozen at these two TFMs. -->
+        <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net471;net462</TargetFrameworks>
+        <!-- Policy is to trim TFM-specific builds to `netstandard2.0`, `net6.0`,
+        all active LTS versions, and optionally the latest RTM version, when releasing new
+        major Serilog versions. -->
+        <TargetFrameworks>$(TargetFrameworks);net8.0;net6.0;netstandard2.0</TargetFrameworks>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+        <SignAssembly>true</SignAssembly>
+        <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+        <PackageTags>serilog;trace;diagnostic</PackageTags>
+        <PackageProjectUrl>https://github.com/serilog/serilog-sinks-trace</PackageProjectUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageIcon>serilog-sink-nuget.png</PackageIcon>
+        <LangVersion>12</LangVersion>
+        <Nullable>enable</Nullable>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <RootNamespace>Serilog</RootNamespace>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Serilog" Version="4.0.0"/>
+        <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all"/>
+    </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\..\assets\serilog-sink-nuget.png">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\..\assets\serilog-sink-nuget.png" Visible="false" PackagePath="/"/>
+        <None Include="..\..\README.md" Visible="false" PackagePath="/"/>
+    </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
+++ b/src/Serilog.Sinks.Trace/Serilog.Sinks.Trace.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>The diagnostic trace sink for Serilog.</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Serilog.Sinks.Trace/TraceLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Trace/TraceLoggerConfigurationExtensions.cs
@@ -12,71 +12,72 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 using System;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting.Display;
-using Serilog.Sinks.DiagnosticTrace;
 using Serilog.Formatting;
 using Serilog.Formatting.Json;
+using Serilog.Sinks.Trace;
 
-namespace Serilog
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedType.Global
+
+namespace Serilog;
+
+/// <summary>
+/// Adds the WriteTo.Trace() extension method to <see cref="LoggerConfiguration"/>.
+/// </summary>
+public static class TraceLoggerConfigurationExtensions
 {
+    const string DefaultOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}";
+
     /// <summary>
-    /// Adds the WriteTo.Trace() extension method to <see cref="LoggerConfiguration"/>.
+    /// Write log events to the <see cref="System.Diagnostics.Trace"/>.
     /// </summary>
-    public static class TraceLoggerConfigurationExtensions
+    /// <param name="sinkConfiguration">Logger sink configuration.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for
+    /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+    /// to be changed at runtime.</param>
+    /// <param name="outputTemplate">A message template describing the format used to write to the sink.
+    /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
+    /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    public static LoggerConfiguration Trace(
+        this LoggerSinkConfiguration sinkConfiguration,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        string outputTemplate = DefaultOutputTemplate,
+        IFormatProvider? formatProvider = null,
+        LoggingLevelSwitch? levelSwitch = null)
     {
-        const string DefaultOutputTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}";
+        if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
+        if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
+        var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
+        return Trace(sinkConfiguration, formatter, restrictedToMinimumLevel, levelSwitch);
+    }
 
-        /// <summary>
-        /// Write log events to the <see cref="System.Diagnostics.Trace"/>.
-        /// </summary>
-        /// <param name="sinkConfiguration">Logger sink configuration.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
-        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
-        /// to be changed at runtime.</param>
-        /// <param name="outputTemplate">A message template describing the format used to write to the sink.
-        /// the default is "{Timestamp} [{Level}] {Message}{NewLine}{Exception}".</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <returns>Configuration object allowing method chaining.</returns>
-        public static LoggerConfiguration Trace(
-            this LoggerSinkConfiguration sinkConfiguration,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            string outputTemplate = DefaultOutputTemplate,
-            IFormatProvider formatProvider = null,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-            if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
-            if (outputTemplate == null) throw new ArgumentNullException(nameof(outputTemplate));
-            var formatter = new MessageTemplateTextFormatter(outputTemplate, formatProvider);
-            return Trace(sinkConfiguration, formatter, restrictedToMinimumLevel, levelSwitch);
-        }
-
-        /// <summary>
-        /// Write log events to the <see cref="System.Diagnostics.Trace"/>.
-        /// </summary>
-        /// <param name="sinkConfiguration">Logger sink configuration.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
-        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
-        /// to be changed at runtime.</param>
-        /// <param name="formatter">A custom formatter to apply to the output events. This can be used with
-        /// e.g. <see cref="JsonFormatter"/> to produce JSON output. To customize the text layout only, use the
-        /// overload that accepts an output template instead.</param>
-        /// <returns>Configuration object allowing method chaining.</returns>
-        public static LoggerConfiguration Trace(
-            this LoggerSinkConfiguration sinkConfiguration,
-            ITextFormatter formatter,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-            if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
-            if (formatter == null) throw new ArgumentNullException(nameof(formatter));
-            return sinkConfiguration.Sink(new TraceSink(formatter), restrictedToMinimumLevel, levelSwitch);
-        }
+    /// <summary>
+    /// Write log events to the <see cref="System.Diagnostics.Trace"/>.
+    /// </summary>
+    /// <param name="sinkConfiguration">Logger sink configuration.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for
+    /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+    /// to be changed at runtime.</param>
+    /// <param name="formatter">A custom formatter to apply to the output events. This can be used with
+    /// e.g. <see cref="JsonFormatter"/> to produce JSON output. To customize the text layout only, use the
+    /// overload that accepts an output template instead.</param>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    public static LoggerConfiguration Trace(
+        this LoggerSinkConfiguration sinkConfiguration,
+        ITextFormatter formatter,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        LoggingLevelSwitch? levelSwitch = null)
+    {
+        if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
+        if (formatter == null) throw new ArgumentNullException(nameof(formatter));
+        return sinkConfiguration.Sink(new TraceSink(formatter), restrictedToMinimumLevel, levelSwitch);
     }
 }

--- a/test/Serilog.Sinks.Trace.Tests/Serilog.Sinks.Trace.Tests.csproj
+++ b/test/Serilog.Sinks.Trace.Tests/Serilog.Sinks.Trace.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp3.1;net50</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,12 +9,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.8.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 * #26 - **breaking** - update to Serilog 4, drop pre-`netstandard2.0` targets (@nblumhardt)
